### PR TITLE
Modding support: added mixins for tree loot drops

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1960,6 +1960,8 @@
       "mixins:simple_destructable_door": "file(mixins/destructable_doors/simple_destructable_door.json)",
       "mixins:simple_iron_destructable_door": "file(mixins/destructable_doors/simple_iron_destructable_door.json)",
       "mixins:simple_stone_destructable_door": "file(mixins/destructable_doors/simple_stone_destructable_door.json)",
+      "mixins:tree:evergreen": "file(mixins/tree/evergreen.json)",
+      "mixins:tree:sapling": "file(mixins/tree/sapling.json)",
       "mixins:tile:simple_carpet": "file(mixins/tile/simple_carpet.json)",
       "mixins:tunnel_destructable_door": "file(mixins/destructable_doors/tunnel_destructable_door.json)",
       "mixins:tunnel_stone_destructable_door": "file(mixins/destructable_doors/tunnel_stone_destructable_door.json)",

--- a/mixins/tree/evergreen.json
+++ b/mixins/tree/evergreen.json
@@ -1,0 +1,28 @@
+{
+  "components": {
+    "stonehearth:loot_drops": {
+      "entries": {
+        "bough_bale": {
+          "mixintypes": {
+            "season": "remove"
+          },
+          "items": {
+            "bough_bale": {
+              "uri": "stonehearth_ace:resources:bough_bale:evergreen"
+            }
+          }
+        },
+        "maybe_bough_bale": {
+          "mixintypes": {
+            "season": "remove"
+          },
+          "items": {
+            "bough_bale": {
+              "uri": "stonehearth_ace:resources:bough_bale:evergreen"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mixins/tree/sapling.json
+++ b/mixins/tree/sapling.json
@@ -1,0 +1,26 @@
+{
+   "components": {
+      "stonehearth:loot_drops": {
+         "entries": {
+            "beehive": {
+               "num_rolls": {
+                  "min": 0,
+                  "max": 0
+               }
+            },
+            "bough_bale": {
+               "num_rolls": {
+                  "min": 0,
+                  "max": 0
+               }
+            },
+            "maybe_bough_bale": {
+               "num_rolls": {
+                  "min": 0,
+                  "max": 0
+               }
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
stonehearth_ace:mixins:tree:evergreen - changes bough drop to evergreen
stonehearth_ace:mixins:tree:sapling - removes loot drops for bough and bees