### PR TITLE
Fix mac shared crash on game load

### DIFF
--- a/data/horde/shaders/voxel/deferred_lighting.shader
+++ b/data/horde/shaders/voxel/deferred_lighting.shader
@@ -13,26 +13,26 @@ sampler2D depths = sampler_state
 };
 
 [[VS]]
+#version 410
 
 uniform mat4 projMat;
-attribute vec3 vertPos;
-varying vec2 texCoords;
-        
+in vec3 vertPos;
+out vec2 texCoords;
+
 void main(void)
 {
-  texCoords = vertPos.xy; 
+  texCoords = vertPos.xy;
   gl_Position = projMat * vec4(vertPos, 1.0);
 }
 
-
 [[FS]]
-#version 120
+#version 410
 #include "/stonehearth/data/horde/shaders/utilityLib/camera_transforms.glsl"
-#include "/stonehearth_ace/data/horde/shaders/utilityLib/fragLighting.glsl" 
+#include "/stonehearth_ace/data/horde/shaders/utilityLib/fragLighting.glsl"
 #include "/stonehearth/data/horde/shaders/utilityLib/desaturate.glsl"
 
 #ifndef DISABLE_SHADOWS
-varying vec4 projShadowPos[3];
+in vec4 projShadowPos[3];
 #include "shaders/shadows.shader"
 #endif
 
@@ -43,11 +43,12 @@ uniform vec3 camViewerPos;
 uniform mat4 camProjMat;
 uniform mat4 camViewMatInv;
 
-varying vec2 texCoords;
+in vec2 texCoords;
+out vec4 fragColor;
 
 void main(void)
 {
-  vec4 normal = texture2D(normals, texCoords);
+  vec4 normal = texture(normals, texCoords);
 
   // Check to see if a valid normal was even written!
   if (normal.w == 0.0) {
@@ -55,7 +56,7 @@ void main(void)
   }
 
   float shadowTerm = 1.0;
-  vec4 depthInfo = texture2D(depths, texCoords);
+  vec4 depthInfo = texture(depths, texCoords);
 
   mat4 lProj = camProjMat;
   mat4 lView = camViewMatInv;
@@ -68,5 +69,5 @@ void main(void)
   vec4 lightColor = calcPhongDirectionalLight(camViewerPos, pos, normal.xyz, depthInfo.b, depthInfo.a) * shadowTerm;
   // Added by ACE, courtesy of Agon
   float ambientShade = calcDirectionalAmbientShade(normal.xyz);
-  gl_FragColor = vec4(globalDesaturate(lightColor.rgb + ambientShade * lightAmbientColor), lightColor.a);
+  fragColor = vec4(globalDesaturate(lightColor.rgb + ambientShade * lightAmbientColor), lightColor.a);
 }


### PR DESCRIPTION
This is a core game problem that was replicated in ACE through the `deferred_lighting.shader` file - the vertex shader was missing a `#version` directive and the fragment shader was still using `#version 120`.

I've upgraded the shader to use `#version 410` syntax - I've seen this in other files in Stonehearth so hoping not breaking minimum spec.

I've tested this working on my M1 running macOS Monterey 12.3.